### PR TITLE
Handled the 409 HTTP error status on the signup page

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-scripts": "4.0.1",
     "react-select": "^4.3.1",
     "react-svg": "^13.0.6",
+    "react-toastify": "^7.0.4",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -105,6 +105,11 @@
 						"action": {
 							"submit": "Sign up"
 						}
+					},
+					"toasts": {
+						"error": {
+							"conflict": "The provided nickname or email address is already linked to an account."
+						}
 					}
 				},
 				"post_signup": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -106,6 +106,11 @@
 						"action": {
 							"submit": "Créer un compte"
 						}
+					},
+					"toasts": {
+						"error": {
+							"conflict": "Le pseudo ou adresse email renseigné est déjà lié à un compte."
+						}
 					}
 				},
 				"post_signup": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,7 @@
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import RouterProvider from 'routes/components/RouterProvider';
 import RouteProvider from 'routes/components/RouteProvider';
 import { MainLayout } from 'components/shared/layout';
@@ -21,6 +23,7 @@ const Root = () => (
 		<RouterProvider>
 			<MainLayout>
 				<RouteProvider />
+				<ToastContainer />
 			</MainLayout>
 		</RouterProvider>
 	</Provider>

--- a/src/lib/shared/http.js
+++ b/src/lib/shared/http.js
@@ -79,7 +79,7 @@ export const handleResponse = (response) => {
 		history.push(routes.auth.logout);
 	}
 
-	if (response.status === 401 || response.status === 403 || response.status === 413 || response.status >= 500) {
+	if (response.status === 401 || response.status === 403 || response.status === 409 || response.status === 413 || response.status >= 500) {
 		return Promise.reject(response);
 	}
 

--- a/src/redux/actions/users.js
+++ b/src/redux/actions/users.js
@@ -1,7 +1,9 @@
+import { toast } from 'react-toastify';
 import * as AuthenticationAPI from 'api/authenticationApi';
 import * as UsersApi from 'api/usersApi';
 import { redirectOnSuccess } from 'lib/shared/redirectionHelper';
 import session from 'lib/shared/session';
+import i18next from 'i18next';
 
 /**
  * @constant
@@ -427,7 +429,13 @@ export const signUp = (params, onSuccessRoute = null) => (dispatch) => {
 			dispatch(signUpSuccess({ user }));
 			redirectOnSuccess(onSuccessRoute);
 		})
-		.catch((error) => dispatch(signUpFailure(error)));
+		.catch((error) => {
+			if (error?.status === 409) {
+				toast.error(i18next.t('authentication.pages.signup.toasts.error.conflict'));
+			}
+
+			dispatch(signUpFailure(error));
+		});
 };
 
 /**

--- a/tests/lib/shared/http.test.js
+++ b/tests/lib/shared/http.test.js
@@ -96,6 +96,12 @@ describe('http helper methods', () => {
 			expect(httpModule.handleResponse(param)).rejects.toEqual(param);
 		});
 
+		it('should return Promise.reject(...) upon reception of a status 409 object.', () => {
+			const param = { status: 409 };
+
+			expect(httpModule.handleResponse(param)).rejects.toEqual(param);
+		});
+
 		it('should return Promise.reject(...) upon reception of a status 413 object.', () => {
 			const param = { status: 413 };
 

--- a/tests/redux/actions/users.test.js
+++ b/tests/redux/actions/users.test.js
@@ -1,6 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
+import { toast } from 'react-toastify';
 import * as usersActions from 'redux/actions/users';
 import { baseUrl } from 'lib/shared/http';
 import session from 'lib/shared/session';
@@ -349,6 +350,29 @@ describe('User-related redux actions', () => {
 			// Act & assert
 			return store.dispatch(usersActions.signUp(userCreationData))
 				.then(() => expect(store.getActions()).toEqual(expectedActions));
+		});
+
+		it('sould trigger an error toast when user login logic has failed with a 409 status', async () => {
+			// Arrange
+			const userCreationData = {
+				firstname: 'john',
+				lastname: 'doe',
+				nickname: 'johnDoe',
+				email: 'johndoe@example.com',
+				password: 'efgh',
+			};
+
+			const httpResponse = { status: 409 };
+
+			fetchMock.post(`${baseUrl}/api/users`, httpResponse);
+
+			const toastSpy = jest.spyOn(toast, 'error');
+
+			// Act
+			await store.dispatch(usersActions.signUp(userCreationData));
+
+			// Assert
+			expect(toastSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/tests/redux/actions/users.test.js
+++ b/tests/redux/actions/users.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
-import { toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import * as usersActions from 'redux/actions/users';
 import { baseUrl } from 'lib/shared/http';
 import session from 'lib/shared/session';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3614,6 +3614,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -9912,6 +9917,13 @@ react-test-renderer@^17.0.0:
     react-is "^17.0.2"
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.2"
+
+react-toastify@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-7.0.4.tgz#7d0b743f2b96f65754264ca6eae31911a82378db"
+  integrity sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react-transition-group@^4.3.0:
   version "4.4.1"


### PR DESCRIPTION
- Users are no longer redirected to the post-signup page whenever a 409 conflict response is sent back from the API.
- An error toast now appears whenever this happens, providing feedback to the users as to why the signup process failed.